### PR TITLE
Fixed "allOf" definitions

### DIFF
--- a/src/bridge/schemas/BridgeGet.yaml
+++ b/src/bridge/schemas/BridgeGet.yaml
@@ -2,19 +2,20 @@ type: object
 description: Definition of a bridge resource
 allOf:
   - $ref: '../../common/ResourceOwned.yaml'
-properties:
-  type:
-    type: string
-    enum:
-      - bridge
-  bridge_id:
-    type: string
-    description: Unique identifier of the bridge as printed on the device. Lower case (shouldn't it be upper case?)
-  time_zone:
-    type: object
+  - type: object
     properties:
-      time_zone:
+      type:
         type: string
-        description: Time zone where the user's home is located (as Olson ID).
+        enum:
+          - bridge
+      bridge_id:
+        type: string
+        description: Unique identifier of the bridge as printed on the device. Lower case (shouldn't it be upper case?)
+      time_zone:
+        type: object
+        properties:
+          time_zone:
+            type: string
+            description: Time zone where the user's home is located (as Olson ID).
 
 

--- a/src/bridge_home/schemas/BridgeHomeGet.yaml
+++ b/src/bridge_home/schemas/BridgeHomeGet.yaml
@@ -2,25 +2,26 @@ type: object
 description: Definition of a bridge resource
 allOf:
   - $ref: '../../common/Resource.yaml'
-properties:
-  type:
-    type: string
-    enum:
-      - bridge_home
-  children:
-    type: array
-    description: Child devices/services to group by the derived group.
-    items:
-      $ref: '../../common/ResourceIdentifier.yaml'
-  services:
-    type: array
-    description: |
-      References all services aggregating control and state of children in the group.
-      This includes all services grouped in the group hierarchy given by child relation.
-      This includes all services of a device grouped in the group hierarchy given by child relation.
-      Aggregation is per service type, ie every service type which can be grouped has a corresponding definition
-      of grouped type Supported types: – grouped_light
-    items:
-      $ref: '../../common/ResourceIdentifier.yaml'
+  - type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - bridge_home
+      children:
+        type: array
+        description: Child devices/services to group by the derived group.
+        items:
+          $ref: '../../common/ResourceIdentifier.yaml'
+      services:
+        type: array
+        description: |
+          References all services aggregating control and state of children in the group.
+          This includes all services grouped in the group hierarchy given by child relation.
+          This includes all services of a device grouped in the group hierarchy given by child relation.
+          Aggregation is per service type, ie every service type which can be grouped has a corresponding definition
+          of grouped type Supported types: – grouped_light
+        items:
+          $ref: '../../common/ResourceIdentifier.yaml'
 
 

--- a/src/common/ResourceOwned.yaml
+++ b/src/common/ResourceOwned.yaml
@@ -2,6 +2,7 @@ type: object
 description: Common resource properties including the owner
 allOf:
   - $ref: './Resource.yaml'
-properties:
-  owner:
-    $ref: './ResourceIdentifier.yaml'
+  - type: object
+    properties:
+      owner:
+        $ref: './ResourceIdentifier.yaml'

--- a/src/light/schemas/LightGet.yaml
+++ b/src/light/schemas/LightGet.yaml
@@ -1,237 +1,239 @@
 type: object
 allOf:
   - $ref: '../../common/ResourceOwned.yaml'
-properties:
-  metadata:
-    type: object
-    description: Deprecated, use metadata on device level
+  - type: object
     properties:
-      name:
-        type: string
-        description: Human readable name of a resource
-      archetype:
-        $ref: './LightArchetype.yaml'
-      fixed_mired:
-        type: integer
-        minimum: 0
-        maximum: 100
-        description: A fixed mired value of the white lamp
-  on:
-    $ref: '../../common/On.yaml'
-  dimming:
-    type: object
-    properties:
-      brightness:
-        $ref: '../../common/Brightness.yaml'
-      min_dim_level:
-        type: integer
-        minimum: 0
-        maximum: 100
-        description: Percentage of the maximum lumen the device outputs on minimum brightness
-  color_temperature:
-    type: object
-    properties:
-      mirek:
-        type: integer
-        minimum: 153
-        maximum: 500
-        description: color temperature in mirek or null when the light color is not in the ct spectrum
-      mirek_valid:
-        type: boolean
-        description: Indication whether the value presented in mirek is valid
-      mirek_schema:
+      metadata:
         type: object
+        description: Deprecated, use metadata on device level
         properties:
-          mirek_minimum:
-            type: integer
-            minimum: 153
-            maximum: 500
-            description: minimum color temperature this light supports
-          mirek_maximum:
-            type: integer
-            minimum: 153
-            maximum: 500
-            description: maximum color temperature this light supports
-  color:
-    type: object
-    properties:
-      xy:
-        $ref: '../../common/GamutPosition.yaml'
-      gamut:
-        type: object
-        description: Color gamut of color bulb. Some bulbs do not properly return the Gamut information. In this case this is not present.
-        properties:
-          red:
-            $ref: '../../common/GamutPosition.yaml'
-          green:
-            $ref: '../../common/GamutPosition.yaml'
-          blue:
-            $ref: '../../common/GamutPosition.yaml'
-      gamut_type:
-        type: string
-        description: The gammut types supported by hue – A Gamut of early Philips color-only products – B Limited gamut of first Hue color products – C Richer color gamut of Hue white and color ambiance products – other Color gamut of non-hue products with non-hue gamuts resp w/o gamut
-        enum:
-          - A
-          - B
-          - C
-          - other
-  dynamics:
-    type: object
-    properties:
-      status:
-        $ref: './SupportedDynamicStatus.yaml'
-      status_values:
-        type: array
-        description: Statuses in which a lamp could be when playing dynamics.
-        items:
-          $ref: './SupportedDynamicStatus.yaml'
-      speed:
-        type: number
-        minimum: 0
-        maximum: 0
-        description: speed of dynamic palette or effect. The speed is valid for the dynamic palette if the status is dynamic_palette or for the corresponding effect listed in status. In case of status none, the speed is not valid
-      speed_valid:
-        type: boolean
-        description: Indicates whether the value presented in speed is valid
-  alert:
-    type: object
-    description: TODO # TODO find the AlertEffectType
-  signaling:
-    type: object
-    description: Feature containing signaling properties.
-    properties:
-      signal_values:
-        type: array
-        items:
-          $ref: './SupportedSignals.yaml'
-      estimated_end:
-        type: integer
-        description: Timestamp indicating when the active signal is expected to end. Value is not set if there is no_signal
-      colors:
-        type: array
-        description: Colors that were provided for the active effect.
-        items:
-          $ref: '../../common/Color.yaml'
-  mode:
-    type: string
-    enum:
-      - normal
-      - streaming
-  gradient:
-    type: object
-    allOf:
-      - $ref: '../../common/Gradient.yaml'
-    properties:
-      points_capable:
-        type: integer
-        description: Number of color points that gradient lamp is capable of showing with gradience.
-      mode_values:
-        type: array
-        description: Modes a gradient device can deploy the gradient palette of colors
-        items:
-          $ref: '../../common/SupportedGradientMode.yaml'
-      pixel_count:
-        type: integer
-        description: Number of pixels in the device
-  effects:
-    type: object
-    description: Basic feature containing effect properties.
-    properties:
-      status:
-        $ref: '../../common/SupportedEffects.yaml'
-      status_values:
-        type: array
-        description: Possible status values in which a light could be when playing an effect.
-        items:
-          $ref: '../../common/SupportedEffects.yaml'
-      effect:
-        $ref: '../../common/SupportedEffects.yaml'
-      effect_values:
-        type: array
-        description: Possible status values in which a light could be when playing an effect.
-        items:
-          $ref: '../../common/SupportedEffects.yaml'
-  timed_effects:
-    type: object
-    description: Basic feature containing timed effect properties.
-    properties:
-      effect:
-        $ref: './SupportedTimedEffects.yaml'
-      effect_values:
-        type: array
-        description: Possible timed effect values you can set in a light.
-        items:
-          $ref: './SupportedTimedEffects.yaml'
-      status:
-        $ref: './SupportedTimedEffects.yaml'
-      status_values:
-        type: array
-        description: Possible status values in which a light could be when playing a timed effect.
-        items:
-          $ref: './SupportedTimedEffects.yaml'
-      duration:
-        type: integer
-        description: Duration is mandatory when timed effect is set except for no_effect. Resolution decreases for a larger duration. e.g Effects with duration smaller than a minute will be rounded to a resolution of 1s, while effects with duration larger than an hour will be arounded up to a resolution of 300s. Duration has a max of 21600000 ms.
-  powerup:
-    type: object
-    description: Feature containing properties to configure powerup behaviour of a lightsource.
-    properties:
-      preset:
-        type: string
-        description: When setting the custom preset the additional properties can be set. For all other presets, no other properties can be included.
-        enum:
-          - safety
-          - powerfail
-          - last_on_state
-          - custom
-      configured:
-        type: boolean
-        description: Indicates if the shown values have been configured in the lightsource.
-      on:
-        type: object
-        properties:
-          mode:
+          name:
             type: string
-            description: |
-              State to activate after powerup.
-              On will use the value specified in the “on” property.
-              When setting mode “on”, the on property must be included.
-              Toggle will alternate between on and off on each subsequent power toggle.
-              Previous will return to the state it was in before powering off.
-            enum:
-              - on
-              - toggle
-              - previous
-          on:
-            $ref: '../../common/On.yaml'
+            description: Human readable name of a resource
+          archetype:
+            $ref: './LightArchetype.yaml'
+          fixed_mired:
+            type: integer
+            minimum: 0
+            maximum: 100
+            description: A fixed mired value of the white lamp
+      on:
+        $ref: '../../common/On.yaml'
       dimming:
         type: object
         properties:
-          mode:
+          brightness:
+            $ref: '../../common/Brightness.yaml'
+          min_dim_level:
+            type: number
+            minimum: 0
+            maximum: 100
+            description: Percentage of the maximum lumen the device outputs on minimum brightness
+      color_temperature:
+        type: object
+        properties:
+          mirek:
+            type: integer
+            minimum: 153
+            maximum: 500
+            description: color temperature in mirek or null when the light color is not in the ct spectrum
+          mirek_valid:
+            type: boolean
+            description: Indication whether the value presented in mirek is valid
+          mirek_schema:
+            type: object
+            properties:
+              mirek_minimum:
+                type: integer
+                minimum: 153
+                maximum: 500
+                description: minimum color temperature this light supports
+              mirek_maximum:
+                type: integer
+                minimum: 153
+                maximum: 500
+                description: maximum color temperature this light supports
+      color:
+        type: object
+        properties:
+          xy:
+            $ref: '../../common/GamutPosition.yaml'
+          gamut:
+            type: object
+            description: Color gamut of color bulb. Some bulbs do not properly return the Gamut information. In this case this is not present.
+            properties:
+              red:
+                $ref: '../../common/GamutPosition.yaml'
+              green:
+                $ref: '../../common/GamutPosition.yaml'
+              blue:
+                $ref: '../../common/GamutPosition.yaml'
+          gamut_type:
             type: string
-            description: |
-              Dimming will set the brightness to the specified value after power up.
-              When setting mode “dimming”, the dimming property must be included.
-              Previous will set brightness to the state it was in before powering off.
+            description: The gammut types supported by hue – A Gamut of early Philips color-only products – B Limited gamut of first Hue color products – C Richer color gamut of Hue white and color ambiance products – other Color gamut of non-hue products with non-hue gamuts resp w/o gamut
             enum:
-              - dimming
-              - previous
-          dimming:
-            $ref: '../../common/Dimming.yaml'
-          color:
+              - A
+              - B
+              - C
+              - other
+      dynamics:
+        type: object
+        properties:
+          status:
+            $ref: './SupportedDynamicStatus.yaml'
+          status_values:
+            type: array
+            description: Statuses in which a lamp could be when playing dynamics.
+            items:
+              $ref: './SupportedDynamicStatus.yaml'
+          speed:
+            type: number
+            minimum: 0
+            maximum: 0
+            description: speed of dynamic palette or effect. The speed is valid for the dynamic palette if the status is dynamic_palette or for the corresponding effect listed in status. In case of status none, the speed is not valid
+          speed_valid:
+            type: boolean
+            description: Indicates whether the value presented in speed is valid
+      alert:
+        type: object
+        description: TODO # TODO find the AlertEffectType
+      signaling:
+        type: object
+        description: Feature containing signaling properties.
+        properties:
+          signal_values:
+            type: array
+            items:
+              $ref: './SupportedSignals.yaml'
+          estimated_end:
+            type: integer
+            description: Timestamp indicating when the active signal is expected to end. Value is not set if there is no_signal
+          colors:
+            type: array
+            description: Colors that were provided for the active effect.
+            items:
+              $ref: '../../common/Color.yaml'
+      mode:
+        type: string
+        enum:
+          - normal
+          - streaming
+      gradient:
+        type: object
+        allOf:
+          - $ref: '../../common/Gradient.yaml'
+          - type: object
+            properties:
+              points_capable:
+                type: integer
+                description: Number of color points that gradient lamp is capable of showing with gradience.
+              mode_values:
+                type: array
+                description: Modes a gradient device can deploy the gradient palette of colors
+                items:
+                  $ref: '../../common/SupportedGradientMode.yaml'
+              pixel_count:
+                type: integer
+                description: Number of pixels in the device
+      effects:
+        type: object
+        description: Basic feature containing effect properties.
+        properties:
+          status:
+            $ref: '../../common/SupportedEffects.yaml'
+          status_values:
+            type: array
+            description: Possible status values in which a light could be when playing an effect.
+            items:
+              $ref: '../../common/SupportedEffects.yaml'
+          effect:
+            $ref: '../../common/SupportedEffects.yaml'
+          effect_values:
+            type: array
+            description: Possible status values in which a light could be when playing an effect.
+            items:
+              $ref: '../../common/SupportedEffects.yaml'
+      timed_effects:
+        type: object
+        description: Basic feature containing timed effect properties.
+        properties:
+          effect:
+            $ref: './SupportedTimedEffects.yaml'
+          effect_values:
+            type: array
+            description: Possible timed effect values you can set in a light.
+            items:
+              $ref: './SupportedTimedEffects.yaml'
+          status:
+            $ref: './SupportedTimedEffects.yaml'
+          status_values:
+            type: array
+            description: Possible status values in which a light could be when playing a timed effect.
+            items:
+              $ref: './SupportedTimedEffects.yaml'
+          duration:
+            type: integer
+            description: Duration is mandatory when timed effect is set except for no_effect. Resolution decreases for a larger duration. e.g Effects with duration smaller than a minute will be rounded to a resolution of 1s, while effects with duration larger than an hour will be arounded up to a resolution of 300s. Duration has a max of 21600000 ms.
+      powerup:
+        type: object
+        description: Feature containing properties to configure powerup behaviour of a lightsource.
+        properties:
+          preset:
+            type: string
+            description: When setting the custom preset the additional properties can be set. For all other presets, no other properties can be included.
+            enum:
+              - safety
+              - powerfail
+              - last_on_state
+              - custom
+          configured:
+            type: boolean
+            description: Indicates if the shown values have been configured in the lightsource.
+          on:
             type: object
             properties:
               mode:
                 type: string
+                description: |
+                  State to activate after powerup.
+                  On will use the value specified in the “on” property.
+                  When setting mode “on”, the on property must be included.
+                  Toggle will alternate between on and off on each subsequent power toggle.
+                  Previous will return to the state it was in before powering off.
                 enum:
-                  - color_temperature
-                  - color
+                  - on
+                  - toggle
                   - previous
-                description: State to activate after powerup. Availability of “color_temperature” and “color” modes depend on the capabilities of the lamp. Colortemperature will set the colortemperature to the specified value after power up. When setting color_temperature, the color_temperature property must be included Color will set the color tot he specified value after power up. When setting color mode, the color property must be included Previous will set color to the state it was in before powering off.
-              color_temperature:
+              on:
+                $ref: '../../common/On.yaml'
+          dimming:
+            type: object
+            properties:
+              mode:
+                type: string
+                description: |
+                  Dimming will set the brightness to the specified value after power up.
+                  When setting mode “dimming”, the dimming property must be included.
+                  Previous will set brightness to the state it was in before powering off.
+                enum:
+                  - dimming
+                  - previous
+              dimming:
+                $ref: '../../common/Dimming.yaml'
+              color:
                 type: object
                 properties:
-                  mirek:
-                    $ref: '../../common/Mirek.yaml'
-                  color:
-                    $ref: '../../common/Color.yaml'
+                  mode:
+                    type: string
+                    enum:
+                      - color_temperature
+                      - color
+                      - previous
+                    description: State to activate after powerup. Availability of “color_temperature” and “color” modes depend on the capabilities of the lamp. Colortemperature will set the colortemperature to the specified value after power up. When setting color_temperature, the color_temperature property must be included Color will set the color tot he specified value after power up. When setting color mode, the color property must be included Previous will set color to the state it was in before powering off.
+                  color_temperature:
+                    type: object
+                    properties:
+                      mirek:
+                        $ref: '../../common/Mirek.yaml'
+                      color:
+                        $ref: '../../common/Color.yaml'

--- a/src/resource/ResourceGet.yaml
+++ b/src/resource/ResourceGet.yaml
@@ -4,43 +4,44 @@ description: |
   documented below.
 allOf:
   - $ref: '../common/ResourceOwned.yaml'
-properties:
-  type:
-    type: string
-    description: Type of the supported resources
-    example: light
-    enum:
-      - device
-      - bridge_home
-      - room
-      - zone
-      - light
-      - button
-      - relative_rotary
-      - temperature
-      - light_level
-      - motion
-      - camera_motion
-      - entertainment
-      - contact
-      - tamper
-      - grouped_light
-      - device_power
-      - zigbee_bridge_connectivity
-      - zigbee_connectivity
-      - zgp_connectivity
-      - bridge
-      - zigbee_device_discovery
-      - homekit
-      - matter
-      - matter_fabric
-      - scene
-      - entertainment_configuration
-      - public_image
-      - auth_v1
-      - behavior_script
-      - behavior_instance
-      - geofence
-      - geofence_client
-      - geolocation
-      - smart_scene
+  - type: object
+    properties:
+      type:
+        type: string
+        description: Type of the supported resources
+        example: light
+        enum:
+          - device
+          - bridge_home
+          - room
+          - zone
+          - light
+          - button
+          - relative_rotary
+          - temperature
+          - light_level
+          - motion
+          - camera_motion
+          - entertainment
+          - contact
+          - tamper
+          - grouped_light
+          - device_power
+          - zigbee_bridge_connectivity
+          - zigbee_connectivity
+          - zgp_connectivity
+          - bridge
+          - zigbee_device_discovery
+          - homekit
+          - matter
+          - matter_fabric
+          - scene
+          - entertainment_configuration
+          - public_image
+          - auth_v1
+          - behavior_script
+          - behavior_instance
+          - geofence
+          - geofence_client
+          - geolocation
+          - smart_scene

--- a/src/room/schemas/RoomGet.yaml
+++ b/src/room/schemas/RoomGet.yaml
@@ -1,30 +1,31 @@
 type: object
 allOf:
   - $ref: '../../common/Resource.yaml'
-properties:
-  children:
-    type: array
-    description: Child devices/services to group by the derived group
-    items:
-      $ref: '../../common/ResourceIdentifier.yaml'
-  services:
-    type: array
-    description: |
-      References all services aggregating control and state of children in the group.
-      This includes all services grouped in the group hierarchy given by child relation.
-      This includes all services of a device grouped in the group hierarchy given by child relation.
-      Aggregation is per service type, ie every service type which can be grouped has a corresponding definition of
-      grouped type.
-      Supported types: – grouped_light
-    items:
-      $ref: '../../common/ResourceIdentifier.yaml'
-  metadata:
-    type: object
-    description: configuration object for a room
+  - type: object
     properties:
-      name:
-        type: string
-        description: Human readable name of a resource
-      archetype:
-        $ref: './RoomArchetype.yaml'
+      children:
+        type: array
+        description: Child devices/services to group by the derived group
+        items:
+          $ref: '../../common/ResourceIdentifier.yaml'
+      services:
+        type: array
+        description: |
+          References all services aggregating control and state of children in the group.
+          This includes all services grouped in the group hierarchy given by child relation.
+          This includes all services of a device grouped in the group hierarchy given by child relation.
+          Aggregation is per service type, ie every service type which can be grouped has a corresponding definition of
+          grouped type.
+          Supported types: – grouped_light
+        items:
+          $ref: '../../common/ResourceIdentifier.yaml'
+      metadata:
+        type: object
+        description: configuration object for a room
+        properties:
+          name:
+            type: string
+            description: Human readable name of a resource
+          archetype:
+            $ref: './RoomArchetype.yaml'
 

--- a/src/scene/schemas/ActionGet.yaml
+++ b/src/scene/schemas/ActionGet.yaml
@@ -1,28 +1,29 @@
 type: object
 allOf:
   - $ref: '../../common/ResourceOwned.yaml'
-properties:
-  target:
-    type: object
-    description: The identifier of the light to execute the action on
-    $ref: '../../common/ResourceIdentifier.yaml'
-  action:
-    type: object
-    description: The action to be executed on recall
+  - type: object
     properties:
-      on:
-        $ref: '../../common/On.yaml'
-      dimming:
-        $ref: '../../common/Dimming.yaml'
-      color:
-        $ref: '../../common/Color.yaml'
-      color_temperature:
-        $ref: '../../common/Mirek.yaml'
-      gradient:
-        $ref: '../../common/Gradient.yaml'
-      effects:
+      target:
         type: object
-        description: Basic feature containing effect properties.
+        description: The identifier of the light to execute the action on
+        $ref: '../../common/ResourceIdentifier.yaml'
+      action:
+        type: object
+        description: The action to be executed on recall
         properties:
-          effect:
-            $ref: '../../common/SupportedEffects.yaml'
+          on:
+            $ref: '../../common/On.yaml'
+          dimming:
+            $ref: '../../common/Dimming.yaml'
+          color:
+            $ref: '../../common/Color.yaml'
+          color_temperature:
+            $ref: '../../common/Mirek.yaml'
+          gradient:
+            $ref: '../../common/Gradient.yaml'
+          effects:
+            type: object
+            description: Basic feature containing effect properties.
+            properties:
+              effect:
+                $ref: '../../common/SupportedEffects.yaml'

--- a/src/scene/schemas/SceneGet.yaml
+++ b/src/scene/schemas/SceneGet.yaml
@@ -1,77 +1,78 @@
 type: object
 allOf:
   - $ref: '../../common/ResourceOwned.yaml'
-properties:
-  type:
-    type: string
-    enum:
-      - scene
-  actions:
-    type: array
-    description: List of actions to be executed synchronously on recall
-    items:
-      $ref: './ActionGet.yaml'
-  metadata:
-    type: object
+  - type: object
     properties:
-      name:
-        type: string
-        minLength: 1
-        maxLength: 32
-        description: Human readable name of a resource
-      image:
-        description: 'Reference with unique identifier for the image representing the scene only accepting “rtype”: “public_image” on creation'
-        $ref: '../../common/ResourceIdentifier.yaml'
-      appdata:
-        type: string
-        minLength: 1
-        maxLength: 16
-        description: Application specific data. Free format string.
-  palette:
-    type: object
-    description: Group of colors that describe the palette of colors to be used when playing dynamics
-    properties:
-      color:
-        type: array
-        minItems: 0
-        maxItems: 9
-        items:
-          $ref: './ColorPaletteGet.yaml'
-      dimming:
-        type: array
-        minItems: 0
-        maxItems: 1
-        items:
-          $ref: '../../common/Dimming.yaml'
-      color_temperature:
-        type: array
-        minItems: 0
-        maxItems: 1
-        items:
-          $ref: './ColorTemperaturePaletteGet.yaml'
-      effects:
-        type: array
-        minItems: 0
-        maxItems: 3
-        items:
-          type: object
-          properties:
-            effect:
-              $ref: '../../common/SupportedEffects.yaml'
-  speed:
-    type: number
-    minimum: 0
-    maximum: 1
-    description: Speed of dynamic palette for this scene
-  auto_dynamic:
-    type: boolean
-    description: Indicates whether to automatically start the scene dynamically on active recall
-  status:
-    type: object
-    properties:
-      active:
+      type:
         type: string
         enum:
-          - inactive
-          - static
-          - dynamic_palette
+          - scene
+      actions:
+        type: array
+        description: List of actions to be executed synchronously on recall
+        items:
+          $ref: './ActionGet.yaml'
+      metadata:
+        type: object
+        properties:
+          name:
+            type: string
+            minLength: 1
+            maxLength: 32
+            description: Human readable name of a resource
+          image:
+            description: 'Reference with unique identifier for the image representing the scene only accepting “rtype”: “public_image” on creation'
+            $ref: '../../common/ResourceIdentifier.yaml'
+          appdata:
+            type: string
+            minLength: 1
+            maxLength: 16
+            description: Application specific data. Free format string.
+      palette:
+        type: object
+        description: Group of colors that describe the palette of colors to be used when playing dynamics
+        properties:
+          color:
+            type: array
+            minItems: 0
+            maxItems: 9
+            items:
+              $ref: './ColorPaletteGet.yaml'
+          dimming:
+            type: array
+            minItems: 0
+            maxItems: 1
+            items:
+              $ref: '../../common/Dimming.yaml'
+          color_temperature:
+            type: array
+            minItems: 0
+            maxItems: 1
+            items:
+              $ref: './ColorTemperaturePaletteGet.yaml'
+          effects:
+            type: array
+            minItems: 0
+            maxItems: 3
+            items:
+              type: object
+              properties:
+                effect:
+                  $ref: '../../common/SupportedEffects.yaml'
+      speed:
+        type: number
+        minimum: 0
+        maximum: 1
+        description: Speed of dynamic palette for this scene
+      auto_dynamic:
+        type: boolean
+        description: Indicates whether to automatically start the scene dynamically on active recall
+      status:
+        type: object
+        properties:
+          active:
+            type: string
+            enum:
+              - inactive
+              - static
+              - dynamic_palette


### PR DESCRIPTION
The previous way to define `allOf` was not working properly with some code generators