### PR TITLE
Fixed the auth response payload

### DIFF
--- a/src/auth/auth.yaml
+++ b/src/auth/auth.yaml
@@ -22,5 +22,17 @@ post:
         application/json:
           schema:
             $ref: ./response.yaml
+          examples:
+            Success:
+              value:
+                - success:
+                    username: a4e08834-0893-4013-b646-738582ec15c9
+                    clientkey: 8c7f2f7e-efb5-4b89-9b54-aac797040ea4
+            Error:
+              value:
+                - error:
+                    type: 101
+                    address: ""
+                    description: link button not pressed
     401:
       $ref: '../common/error.yaml#/components/responses/Unauthorized'

--- a/src/auth/response.yaml
+++ b/src/auth/response.yaml
@@ -1,9 +1,24 @@
-type: object
-properties:
-  success:
-    type: object
-    properties:
-      username:
-        type: string
-      clientkey:
-        type: string
+type: array
+minItems: 1
+maxItems: 1
+items:
+  type: object
+  properties:
+    success:
+      type: object
+      properties:
+        username:
+          type: string
+        clientkey:
+          type: string
+    error:
+      type: object
+      properties:
+        type:
+          type: integer
+          example: 101
+        address:
+          type: string
+        description:
+          type: string
+          example: link button bot pressed


### PR DESCRIPTION
The `/api` endpoint returns an `array` of objects, and the response object directly. 