### PR TITLE
Fixed the /device path, prefixed with /resource

### DIFF
--- a/src/main.yaml
+++ b/src/main.yaml
@@ -54,14 +54,14 @@ paths:
   /clip/v2/resource:
     $ref: './resource/resource.yaml'
 #  Device
-  /clip/v2/device:
+  /clip/v2/resource/device:
     $ref: './device/device.yaml'
-  /clip/v2/device/{deviceId}:
+  /clip/v2/resource/device/{deviceId}:
     $ref: './device/device_{deviceId}.yaml'
 #  Device Power
-  /clip/v2/device_power:
+  /clip/v2/resource/device_power:
     $ref: './device_power/device_power.yaml'
-  /clip/v2/device_power/{deviceId}:
+  /clip/v2/resource/device_power/{deviceId}:
     $ref: './device_power/device_power_{deviceId}.yaml'
 #  Light
   /clip/v2/resource/light:


### PR DESCRIPTION
The `/device` and `/device_power` were not prefixed the `/resource`