### PR TITLE
Fixed the Product/Archetype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ setup: ## Setup the dev environment
 .PHONY: build
 build: _check-redocly-installation ## Bundle the OpenAPI single-file specification in the ./build folder
 	@echo "Building the OpenAPI single-file specification..."
-	@redocly bundle --lint -o build/openhue.yaml
+	@redocly bundle -o build/openhue.yaml
 
 .PHONY: verify
 verify: _check-redocly-installation ## Check that the specification is valid

--- a/src/device/schemas/DeviceGet.yaml
+++ b/src/device/schemas/DeviceGet.yaml
@@ -1,5 +1,5 @@
 type: object
-description: Definition of a bridge resource
+description: Definition of a device resource
 allOf:
   - $ref: '../../common/ResourceOwned.yaml'
   - type: object
@@ -19,8 +19,7 @@ allOf:
             maxLength: 32
             description: Human readable name of a resource
           archetype:
-            $ref: './ProductData.yaml'
-            description: By default archetype given by manufacturer. Can be changed by user.
+            $ref: './ProductArchetype.yaml'
       usertest:
         type: object
         properties:

--- a/src/device/schemas/DevicePut.yaml
+++ b/src/device/schemas/DevicePut.yaml
@@ -14,7 +14,6 @@ properties:
         description: Human readable name of a resource
       archetype:
         $ref: './ProductArchetype.yaml'
-        description: By default archetype given by manufacturer. Can be changed by user.
   identify:
     type: object
     properties:

--- a/src/device/schemas/ProductArchetype.yaml
+++ b/src/device/schemas/ProductArchetype.yaml
@@ -1,8 +1,8 @@
 type: string
-description: Archetype of the product
+description: The default archetype given by manufacturer. Can be changed by user.
 example: hue_go
 enum:
-  - one of bridge_v2
+  - bridge_v2
   - unknown_archetype
   - classic_bulb
   - sultan_bulb

--- a/src/device_power/schemas/DevicePowerGet.yaml
+++ b/src/device_power/schemas/DevicePowerGet.yaml
@@ -1,5 +1,5 @@
 type: object
-description: Definition of a bridge resource
+description: Definition of a bridge power resource
 allOf:
   - $ref: '../../common/ResourceOwned.yaml'
   - type: object

--- a/src/light/schemas/LightArchetype.yaml
+++ b/src/light/schemas/LightArchetype.yaml
@@ -1,5 +1,6 @@
 type: string
 description: Light archetype
+example: classic_bulb
 enum:
   - unknown_archetype
   - classic_bulb


### PR DESCRIPTION
This was causing a code generation issue in the [openhue-cli](https://github.com/openhue/openhue-cli) project: 
```
Error: json: cannot unmarshal string into Go struct field .data.metadata.archetype of type gen.ProductData
```