### PR TITLE
No more nested objects in the ScenePut and ScenePost payloads

### DIFF
--- a/src/scene/schemas/SceneGet.yaml
+++ b/src/scene/schemas/SceneGet.yaml
@@ -13,54 +13,11 @@ allOf:
         items:
           $ref: './ActionGet.yaml'
       metadata:
-        type: object
-        properties:
-          name:
-            type: string
-            minLength: 1
-            maxLength: 32
-            description: Human readable name of a resource
-          image:
-#            description: 'Reference with unique identifier for the image representing the scene only accepting “rtype”: “public_image” on creation'
-            $ref: '../../common/ResourceIdentifier.yaml'
-          appdata:
-            type: string
-            minLength: 1
-            maxLength: 16
-            description: Application specific data. Free format string.
+        $ref: './SceneMetadata.yaml'
       group:
         $ref: '../../common/ResourceIdentifier.yaml'
       palette:
-        type: object
-        description: Group of colors that describe the palette of colors to be used when playing dynamics
-        properties:
-          color:
-            type: array
-            minItems: 0
-            maxItems: 9
-            items:
-              $ref: './ColorPaletteGet.yaml'
-          dimming:
-            type: array
-            minItems: 0
-            maxItems: 1
-            items:
-              $ref: '../../common/Dimming.yaml'
-          color_temperature:
-            type: array
-            minItems: 0
-            maxItems: 1
-            items:
-              $ref: './ColorTemperaturePaletteGet.yaml'
-          effects:
-            type: array
-            minItems: 0
-            maxItems: 3
-            items:
-              type: object
-              properties:
-                effect:
-                  $ref: '../../common/SupportedEffects.yaml'
+        $ref: './ScenePalette.yaml'
       speed:
         type: number
         minimum: 0

--- a/src/scene/schemas/SceneMetadata.yaml
+++ b/src/scene/schemas/SceneMetadata.yaml
@@ -1,0 +1,14 @@
+type: object
+properties:
+  name:
+    type: string
+    minLength: 1
+    maxLength: 32
+    description: Human readable name of a resource
+  image:
+    $ref: '../../common/ResourceIdentifier.yaml'
+  appdata:
+    type: string
+    minLength: 1
+    maxLength: 16
+    description: Application specific data. Free format string.

--- a/src/scene/schemas/ScenePalette.yaml
+++ b/src/scene/schemas/ScenePalette.yaml
@@ -1,0 +1,30 @@
+type: object
+description: Group of colors that describe the palette of colors to be used when playing dynamics
+properties:
+  color:
+    type: array
+    minItems: 0
+    maxItems: 9
+    items:
+      $ref: './ColorPaletteGet.yaml'
+  dimming:
+    type: array
+    minItems: 0
+    maxItems: 1
+    items:
+      $ref: '../../common/Dimming.yaml'
+  color_temperature:
+    type: array
+    minItems: 0
+    maxItems: 1
+    items:
+      $ref: './ColorTemperaturePalettePost.yaml'
+  effects:
+    type: array
+    minItems: 0
+    maxItems: 3
+    items:
+      type: object
+      properties:
+        effect:
+          $ref: '../../common/SupportedEffects.yaml'

--- a/src/scene/schemas/ScenePost.yaml
+++ b/src/scene/schemas/ScenePost.yaml
@@ -14,57 +14,11 @@ properties:
     items:
       $ref: './ActionPost.yaml'
   metadata:
-    type: object
-    properties:
-      name:
-        type: string
-        minLength: 1
-        maxLength: 32
-        description: Human readable name of a resource
-      image:
-        description: 'Reference with unique identifier for the image representing the scene only accepting “rtype”: “public_image” on creation'
-        $ref: '../../common/ResourceIdentifier.yaml'
-      appdata:
-        type: string
-        minLength: 1
-        maxLength: 16
-        description: Application specific data. Free format string.
+    $ref: './SceneMetadata.yaml'
   group:
-    description: |
-      Group associated with this Scene. All services in the group are part of this scene.
-      If the group is changed the scene is update (e.g. light added/removed)
     $ref: '../../common/ResourceIdentifier.yaml'
   palette:
-    type: object
-    description: Group of colors that describe the palette of colors to be used when playing dynamics
-    properties:
-      color:
-        type: array
-        minItems: 0
-        maxItems: 9
-        items:
-          $ref: './ColorPaletteGet.yaml'
-      dimming:
-        type: array
-        minItems: 0
-        maxItems: 1
-        items:
-          $ref: '../../common/Dimming.yaml'
-      color_temperature:
-        type: array
-        minItems: 0
-        maxItems: 1
-        items:
-          $ref: './ColorTemperaturePalettePost.yaml'
-      effects:
-        type: array
-        minItems: 0
-        maxItems: 3
-        items:
-          type: object
-          properties:
-            effect:
-              $ref: '../../common/SupportedEffects.yaml'
+    $ref: './ScenePalette.yaml'
   speed:
     type: number
     minimum: 0

--- a/src/scene/schemas/ScenePut.yaml
+++ b/src/scene/schemas/ScenePut.yaml
@@ -1,8 +1,4 @@
 type: object
-required:
-  - actions
-  - metadata
-  - group
 properties:
   type:
     type: string
@@ -14,67 +10,11 @@ properties:
     items:
       $ref: './ActionPost.yaml'
   recall:
-    type: object
-    properties:
-      action:
-        type: string
-        description: When writing active, the actions in the scene are executed on the target. dynamic_palette starts dynamic scene with colors in the Palette object.
-        enum:
-          - active
-          - dynamic_palette
-          - static
-      duration:
-        type: integer
-        description: Transition to the scene within the timeframe given by duration
-      dimming:
-        $ref: '../../common/Dimming.yaml'
+    $ref: './SceneRecall.yaml'
   metadata:
-    type: object
-    properties:
-      name:
-        type: string
-        minLength: 1
-        maxLength: 32
-        description: Human readable name of a resource
-      image:
-        description: 'Reference with unique identifier for the image representing the scene only accepting “rtype”: “public_image” on creation'
-        $ref: '../../common/ResourceIdentifier.yaml'
-      appdata:
-        type: string
-        minLength: 1
-        maxLength: 16
-        description: Application specific data. Free format string.
+    $ref: './SceneMetadata.yaml'
   palette:
-    type: object
-    description: Group of colors that describe the palette of colors to be used when playing dynamics
-    properties:
-      color:
-        type: array
-        minItems: 0
-        maxItems: 9
-        items:
-          $ref: './ColorPaletteGet.yaml'
-      dimming:
-        type: array
-        minItems: 0
-        maxItems: 1
-        items:
-          $ref: '../../common/Dimming.yaml'
-      color_temperature:
-        type: array
-        minItems: 0
-        maxItems: 1
-        items:
-          $ref: './ColorTemperaturePalettePost.yaml'
-      effects:
-        type: array
-        minItems: 0
-        maxItems: 3
-        items:
-          type: object
-          properties:
-            effect:
-              $ref: '../../common/SupportedEffects.yaml'
+    $ref: './ScenePalette.yaml'
   speed:
     type: number
     minimum: 0

--- a/src/scene/schemas/SceneRecall.yaml
+++ b/src/scene/schemas/SceneRecall.yaml
@@ -1,0 +1,14 @@
+type: object
+properties:
+  action:
+    type: string
+    description: When writing active, the actions in the scene are executed on the target. dynamic_palette starts dynamic scene with colors in the Palette object.
+    enum:
+      - active
+      - dynamic_palette
+      - static
+  duration:
+    type: integer
+    description: Transition to the scene within the timeframe given by duration
+  dimming:
+    $ref: '../../common/Dimming.yaml'


### PR DESCRIPTION
While working on https://github.com/openhue/openhue-cli/pull/41, I realized that nested objects are difficult to initalize from Go-generated client code.  