### PR TITLE
fix: update fixed_mired min and max values

### DIFF
--- a/src/light/schemas/LightGet.yaml
+++ b/src/light/schemas/LightGet.yaml
@@ -14,8 +14,8 @@ allOf:
             $ref: './LightArchetype.yaml'
           fixed_mired:
             type: integer
-            minimum: 0
-            maximum: 100
+            minimum: 153
+            maximum: 500
             description: A fixed mired value of the white lamp
       on:
         $ref: '../../common/On.yaml'


### PR DESCRIPTION
Updated fixed_mired min and max values as per Hue CLIP API documentation version v2.

See: https://developers.meethue.com/develop/hue-api-v2/api-reference/#resource_light_get:~:text=on%20device%20level-,fixed_mired,-%3A%20(integer%20%E2%80%93%20minimum

Thanks for the great work!